### PR TITLE
test: Add missing URL escape for query parameter

### DIFF
--- a/test/system/search_test.rb
+++ b/test/system/search_test.rb
@@ -325,7 +325,7 @@ class SearchTest < ApplicationSystemTestCase
 
       label = I18n.t("category.test")
       drilldown("#{label} (1)")
-      assert_equal("/search/query/unknown+type%3F/category/test", current_path)
+      assert_equal("/search/query/unknown+type%253F/category/test", current_path)
       assert_found(:n_entries => 1,
                    :drilldown => {:type => ["unknown"]},
                    :pagination => "1/1")


### PR DESCRIPTION
## Problem

Path test for query parameter that includes `?` is failed:

https://github.com/ranguba/ranguba/actions/runs/8917379065/job/24490351055#step:12:10

```text
Failure: test_question_in_context(SearchTest::DrilldownTest)
/home/runner/work/ranguba/ranguba/test/system/search_test.rb:328:in `test_question_in_context'
     325: 
     326:       label = I18n.t("category.test")
     327:       drilldown("#{label} (1)")
  => 328:       assert_equal("/search/query/unknown+type%3F/category/test", current_path)
     329:       assert_found(:n_entries => 1,
     330:                    :drilldown => {:type => ["unknown"]},
     331:                    :pagination => "1/1")
<"/search/query/unknown+type%3F/category/test"> expected but was
<"/search/query/unknown+type%253F/category/test">
```

## What I checked

I used the query like `unknow type?` on my local environment.
The URL escaped path is  `/search/query/unknown+type%253F/category/test`.
So I judged the expected query path was wrong.

![Screenshot from 2024-05-09 13-06-57](https://github.com/ranguba/ranguba/assets/45173523/fa9d78f1-d77e-4387-b9c5-1b0114d63d20)