### PR TITLE
Drop support for Ruby below versions 2.6

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,8 +10,6 @@ jobs:
       fail-fast: false
       matrix:
         ruby-version:
-          - "2.5"
-          - "2.6"
           - "2.7"
           - "3.0"
     steps:


### PR DESCRIPTION
Below Ruby version 3.0 is EOL. We drop these versions except for version 2.7 and 3.0.
- ref: https://www.ruby-lang.org/en/downloads/

We keep supporting Ruby 2.7 and 3.0 because Rails version 7 which we will use as a next version supports Ruby version 2.7 and 3.0. So we won't drop them in this moment.
- ref: https://github.com/rails/rails/blob/7-0-stable/rails.gemspec#L12