### PR TITLE
Use sprockets-rails explicitly

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -74,6 +74,8 @@ end
 gem "kaminari-core"
 gem "kaminari-actionview"
 
+gem "sprockets-rails"
+
 group :development, :test do
   gem "test-unit"
   gem "test-unit-rails"


### PR DESCRIPTION
ref: https://github.com/ranguba/ranguba/issues/7

From Rails version 7.0, Sprockets will be an optional dependency.
ref: https://guides.rubyonrails.org/upgrading_ruby_on_rails.html#sprockets-is-now-an-optional-dependency