### PR TITLE
Allow `@rails/ujs` package to update patch versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "dependencies": {
     "@rails/actioncable": "^6.0.0",
-    "@rails/ujs": "7.0.0",
+    "@rails/ujs": "~7.0.0",
     "@rails/webpacker": "5.2.1",
     "turbolinks": "^5.2.0"
   },


### PR DESCRIPTION

ref: https://github.com/npm/node-semver?tab=readme-ov-file#tilde-ranges-123-12-1

Added: Because updating patch version improves the security safety and reliability of the application without breaking changes.