### PR TITLE
Update @rails/actioncable to v7.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ranguba",
   "private": true,
   "dependencies": {
-    "@rails/actioncable": "^6.0.0",
+    "@rails/actioncable": "~7.0.0",
     "@rails/ujs": "~7.0.0",
     "@rails/webpacker": "5.2.1",
     "turbolinks": "^5.2.0"


### PR DESCRIPTION
ref: https://github.com/ranguba/ranguba/issues/7

There are no breaking changes that affect the Ranguba application.
Also, we accepts the updated patch versions because it improves the security safety and reliability of the application without breaking changes.

ref: https://github.com/rails/rails/releases/tag/v7.0.0
ref: ~~https://guides.rubyonrails.org/upgrading_ruby_on_rails.html#upgrading-from-rails-7-0-to-rails-7-1~~
* https://guides.rubyonrails.org/upgrading_ruby_on_rails.html#upgrading-from-rails-6-0-to-rails-6-1
* https://guides.rubyonrails.org/upgrading_ruby_on_rails.html#upgrading-from-rails-6-1-to-rails-7-0