### PR TITLE
Explicitly require `sprockets/railtie` in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -74,7 +74,7 @@ end
 gem "kaminari-core"
 gem "kaminari-actionview"
 
-gem "sprockets-rails"
+gem "sprockets-rails", :require => "sprockets/railtie"
 
 group :development, :test do
   gem "test-unit"

--- a/config/application.rb
+++ b/config/application.rb
@@ -12,7 +12,6 @@ require "action_mailer/railtie"
 # require "action_text/engine"
 require "action_view/railtie"
 require "action_cable/engine"
-require "sprockets/railtie"
 require "rails/test_unit/railtie"
 
 require "groonga_client_model/railtie"


### PR DESCRIPTION
ref: https://github.com/ranguba/ranguba/pull/9#discussion_r1646783333
ref: https://github.com/ranguba/ranguba/issues/7

This change allows us to easily remove `Sprockets` in near future.
And also it will be easy to maintain it because we don't have to think whether it is needed or not when executing `rails app:update` will automatically remove `require sprockets/railtie`.

ref: https://github.com/rails/sprockets-rails?tab=readme-ov-file#installation