### PR TITLE
Remove gem `listen`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,7 +34,6 @@ group :development do
   # Display performance information such as SQL time and flame graphs for each request in your browser.
   # Can be configured to work on production as well see: https://github.com/MiniProfiler/rack-mini-profiler/blob/master/README.md
   gem "rack-mini-profiler", "~> 2.0"
-  gem "listen", "~> 3.3"
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   # gem "spring"
 end


### PR DESCRIPTION
ref: https://github.com/ranguba/ranguba/issues/7

The `listen` gem is no longer required as ActiveSupport::EventedFileUpdateChecker, which depended on it, has been replaced by ActiveSupport::FileUpdateChecker starting from Rails v7.0.0.

- https://github.com/rails/rails/commit/e34300a921a910c60cd4064038b0817fe0e0ab18
- https://github.com/ranguba/ranguba/pull/9#discussion_r1645347560