### PR TITLE
config: `button_to` generates `button_tag`

### DIFF
--- a/config/initializers/new_framework_defaults_7_0.rb
+++ b/config/initializers/new_framework_defaults_7_0.rb
@@ -11,7 +11,7 @@
 
 # `button_to` view helper will render `<button>` element, regardless of whether
 # or not the content is passed as the first argument or as a block.
-# Rails.application.config.action_view.button_to_generates_button_tag = true
+Rails.application.config.action_view.button_to_generates_button_tag = true
 
 # `stylesheet_link_tag` view helper will not render the media attribute by default.
 # Rails.application.config.action_view.apply_stylesheet_media_default = false


### PR DESCRIPTION
ref: https://github.com/ranguba/ranguba/issues/7

From Rails v7, this setting is Rails's default.
In Ranguba, we don't use `button_to` so there is no effect.

ref: https://guides.rubyonrails.org/configuring.html#config-action-view-button-to-generates-button-tag