### PR TITLE
config: migrate digest class for ActiveSupport::Digest changing to SHA256

### DIFF
--- a/config/initializers/new_framework_defaults_7_0.rb
+++ b/config/initializers/new_framework_defaults_7_0.rb
@@ -23,12 +23,12 @@ Rails.application.config.action_view.apply_stylesheet_media_default = false
 #
 # See upgrading guide for more information on how to build a rotator.
 # https://guides.rubyonrails.org/v7.0/upgrading_ruby_on_rails.html
-# Rails.application.config.active_support.key_generator_hash_digest_class = OpenSSL::Digest::SHA256
+Rails.application.config.active_support.key_generator_hash_digest_class = OpenSSL::Digest::SHA256
 
 # Change the digest class for ActiveSupport::Digest.
 # Changing this default means that for example Etags change and
 # various cache keys leading to cache invalidation.
-# Rails.application.config.active_support.hash_digest_class = OpenSSL::Digest::SHA256
+Rails.application.config.active_support.hash_digest_class = OpenSSL::Digest::SHA256
 
 # Don't override ActiveSupport::TimeWithZone.name and use the default Ruby
 # implementation.


### PR DESCRIPTION
This change affects the encrypted cookies and etags. If our application uses it, we should add the rotator from SHA1 to SHA256.

In Ranguba, we don't use cookies and etags which are related to this change. So I think we don't have to deal with it.

ref: https://guides.rubyonrails.org/v7.0/upgrading_ruby_on_rails.html#key-generator-digest-class-changing-to-use-sha256
ref: https://guides.rubyonrails.org/v7.0/upgrading_ruby_on_rails.html#digest-class-for-activesupport-digest-changing-to-sha256

## For reviewers
If we have to add the rorater for the Ranguba users who add the additonal functions using ActiveSupport::Digest, please let me know.