### PR TITLE
config: remove deprecated time with zone name

### DIFF
--- a/config/initializers/new_framework_defaults_7_0.rb
+++ b/config/initializers/new_framework_defaults_7_0.rb
@@ -32,7 +32,7 @@ Rails.application.config.active_support.hash_digest_class = OpenSSL::Digest::SHA
 
 # Don't override ActiveSupport::TimeWithZone.name and use the default Ruby
 # implementation.
-# Rails.application.config.active_support.remove_deprecated_time_with_zone_name = true
+Rails.application.config.active_support.remove_deprecated_time_with_zone_name = true
 
 # Calls `Rails.application.executor.wrap` around test cases.
 # This makes test cases behave closer to an actual request or job.


### PR DESCRIPTION
From Rails v7, this is default setting.
Removing the deprecated override of the `ActiveSupport::TimeWithZone.name` method, it calls `Module#name` which is Ruby default implementation method.

Before

```ruby
> ActiveSupport::TimeWithZone.name
=> "Time"
```

After

```ruby
> ActiveSupport::TimeWithZone.name
=> "ActiveSupport::TimeWithZone"
```

ref: https://guides.rubyonrails.org/v7.0.4/configuring.html#config-active-support-remove-deprecated-time-with-zone-name