### PR TITLE
config: enables `Rails.application.executor.wrap` to run around test cases

### DIFF
--- a/config/initializers/new_framework_defaults_7_0.rb
+++ b/config/initializers/new_framework_defaults_7_0.rb
@@ -38,7 +38,7 @@ Rails.application.config.active_support.remove_deprecated_time_with_zone_name = 
 # This makes test cases behave closer to an actual request or job.
 # Several features that are normally disabled in test, such as Active Record query cache
 # and asynchronous queries will then be enabled.
-# Rails.application.config.active_support.executor_around_test_case = true
+Rails.application.config.active_support.executor_around_test_case = true
 
 # Set both the `:open_timeout` and `:read_timeout` values for `:smtp` delivery method.
 # Rails.application.config.action_mailer.smtp_timeout = 5


### PR DESCRIPTION
From Rails v7.0, this setting is default.
This makes test cases behave closer to an actual request or job. Several features that are normally disabled in test, such as Active Record query cache and asynchronous queries will then be enabled.

ref: https://guides.rubyonrails.org/configuring.html#config-active-support-executor-around-test-case