### PR TITLE
config action-mailer: set the default timeout for SMPT

### DIFF
--- a/config/initializers/new_framework_defaults_7_0.rb
+++ b/config/initializers/new_framework_defaults_7_0.rb
@@ -41,7 +41,7 @@ Rails.application.config.active_support.remove_deprecated_time_with_zone_name = 
 Rails.application.config.active_support.executor_around_test_case = true
 
 # Set both the `:open_timeout` and `:read_timeout` values for `:smtp` delivery method.
-# Rails.application.config.action_mailer.smtp_timeout = 5
+Rails.application.config.action_mailer.smtp_timeout = 5
 
 # The ActiveStorage video previewer will now use scene change detection to generate
 # better preview images (rather than the previous default of using the first frame


### PR DESCRIPTION
From Rails v7.0.0, this setting is default.
It enables app to set default values for both `:open_timeout` and `:read_timeout` in the mail gem.

In Ranguba, we don't use ActionMailer, so there is no effect.

ref: https://guides.rubyonrails.org/configuring.html#config-action-mailer-smtp-timeout