### PR TITLE
config active storage: fix undefined method `active_storage' error

### DIFF
--- a/config/initializers/new_framework_defaults_7_0.rb
+++ b/config/initializers/new_framework_defaults_7_0.rb
@@ -46,8 +46,11 @@ Rails.application.config.action_mailer.smtp_timeout = 5
 # The ActiveStorage video previewer will now use scene change detection to generate
 # better preview images (rather than the previous default of using the first frame
 # of the video).
-Rails.application.config.active_storage.video_preview_arguments =
-  "-vf 'select=eq(n\\,0)+eq(key\\,1)+gt(scene\\,0.015),loop=loop=-1:size=2,trim=start_frame=1' -frames:v 1 -f image2"
+#
+# Added: If this setting is enabled in application which doesn't use Active Storage, it raises a error.
+# We will comment out this setting because we don't use Active Storage.
+# Rails.application.config.active_storage.video_preview_arguments =
+#   "-vf 'select=eq(n\\,0)+eq(key\\,1)+gt(scene\\,0.015),loop=loop=-1:size=2,trim=start_frame=1' -frames:v 1 -f image2"
 
 # Automatically infer `inverse_of` for associations with a scope.
 # Rails.application.config.active_record.automatic_scope_inversing = true


### PR DESCRIPTION

CI failed because of https://github.com/ranguba/ranguba/pull/23

In Ranguba, Active Storage isn't enabled at the following. So it will be a error if we enable its setting.

https://github.com/ranguba/ranguba/blob/5a1c8dfd9e027dcd906abd96734445a5e5a9a744/config/application.rb#L8