### PR TITLE
config: added comments to changes we don't need

### DIFF
--- a/config/initializers/new_framework_defaults_7_0.rb
+++ b/config/initializers/new_framework_defaults_7_0.rb
@@ -52,12 +52,15 @@ Rails.application.config.action_mailer.smtp_timeout = 5
 # Rails.application.config.active_storage.video_preview_arguments =
 #   "-vf 'select=eq(n\\,0)+eq(key\\,1)+gt(scene\\,0.015),loop=loop=-1:size=2,trim=start_frame=1' -frames:v 1 -f image2"
 
+# Added: We dont' use Active Record in Ranguba. So we don't need it.
 # Automatically infer `inverse_of` for associations with a scope.
 # Rails.application.config.active_record.automatic_scope_inversing = true
 
+# Added: We dont' use Active Record in Ranguba. So we don't need it.
 # Raise when running tests if fixtures contained foreign key violations
 # Rails.application.config.active_record.verify_foreign_keys_for_fixtures = true
 
+# Added: We dont' use Active Record in Ranguba. So we don't need it.
 # Disable partial inserts.
 # This default means that all columns will be referenced in INSERT queries
 # regardless of whether they have a default or not.
@@ -66,6 +69,7 @@ Rails.application.config.action_mailer.smtp_timeout = 5
 # Protect from open redirect attacks in `redirect_back_or_to` and `redirect_to`.
 # Rails.application.config.action_controller.raise_on_open_redirects = true
 
+# Added: We dont' use Active Storage in Ranguba. So we don't need it.
 # Change the variant processor for Active Storage.
 # Changing this default means updating all places in your code that
 # generate variants to use image processing macros and ruby-vips
@@ -135,6 +139,7 @@ Rails.application.config.action_mailer.smtp_timeout = 5
 # Change the return value of `ActionDispatch::Request#content_type` to the Content-Type header without modification.
 # Rails.application.config.action_dispatch.return_only_request_media_type_on_content_type = false
 
+# Added: We dont' use Active Storage in Ranguba. So we don't need it.
 # Active Storage `has_many_attached` relationships will default to replacing the current collection instead of appending to it.
 # Thus, to support submitting an empty collection, the `file_field` helper will render an hidden field `include_hidden` by default when `multiple_file_field_include_hidden` is set to `true`.
 # See https://guides.rubyonrails.org/configuring.html#config-active-storage-multiple-file-field-include-hidden for more information.


### PR DESCRIPTION
Because we don't use the following functions.
- Active Record
- Active Storage