### PR TITLE
config action controller: enabled protection for open redirect attacks

### DIFF
--- a/config/initializers/new_framework_defaults_7_0.rb
+++ b/config/initializers/new_framework_defaults_7_0.rb
@@ -67,7 +67,7 @@ Rails.application.config.action_mailer.smtp_timeout = 5
 # Rails.application.config.active_record.partial_inserts = false
 
 # Protect from open redirect attacks in `redirect_back_or_to` and `redirect_to`.
-# Rails.application.config.action_controller.raise_on_open_redirects = true
+Rails.application.config.action_controller.raise_on_open_redirects = true
 
 # Added: We dont' use Active Storage in Ranguba. So we don't need it.
 # Change the variant processor for Active Storage.


### PR DESCRIPTION
> Protect an application from unintentionally redirecting to an external host (also known as an "open redirect")
> by making external redirects opt-in.

This setting is being changed to default in Rails 7.
If we want to make users redirect to the other host, we can pass `allow_other_host` to `ActionController::Redirecting #redirect_to`.
- https://api.rubyonrails.org/v7.1.3.4/classes/ActionController/Redirecting.html#method-i-redirect_to

ref: https://guides.rubyonrails.org/configuring.html#config-action-controller-raise-on-open-redirects
ref: https://github.com/rails/rails/commit/5e93cff83599833380b4cb3d99c020b5efc7dd96