### PR TITLE
config action controller: enable parameter wrapping for JSON by default

### DIFF
--- a/config/initializers/new_framework_defaults_7_0.rb
+++ b/config/initializers/new_framework_defaults_7_0.rb
@@ -80,7 +80,7 @@ Rails.application.config.action_controller.raise_on_open_redirects = true
 # Enable parameter wrapping for JSON.
 # Previously this was set in an initializer. It's fine to keep using that initializer if you've customized it.
 # To disable parameter wrapping entirely, set this config to `false`.
-# Rails.application.config.action_controller.wrap_parameters_by_default = true
+Rails.application.config.action_controller.wrap_parameters_by_default = true
 
 # Specifies whether generated namespaced UUIDs follow the RFC 4122 standard for namespace IDs provided as a
 # `String` to `Digest::UUID.uuid_v3` or `Digest::UUID.uuid_v5` method calls.

--- a/config/initializers/wrap_parameters.rb
+++ b/config/initializers/wrap_parameters.rb
@@ -1,9 +1,0 @@
-# Be sure to restart your server when you modify this file.
-
-# This file contains settings for ActionController::ParamsWrapper which
-# is enabled by default.
-
-# Enable parameter wrapping for JSON. You can disable this by setting :format to an empty array.
-ActiveSupport.on_load(:action_controller) do
-  wrap_parameters format: [:json]
-end


### PR DESCRIPTION
GitHub: ref GH-7

This setting is being changed to default in Rails v7.
Setting this configuration value to true has the same behavior as the initializer.
It means `config/initializers/wrap_parameters.rb` will not be generated anymore in Rails v7.
- https://github.com/rails/rails/tree/main/railties/lib/rails/generators/rails/app/templates/config/initializers

There is no effect to Ranguba because we don't use any custom parameter wrappings.

ref: https://guides.rubyonrails.org/configuring.html#config-action-controller-wrap-parameters-by-default