### PR TITLE
config active support: follow the RFC 4122 standard for namespace IDs

### DIFF
--- a/config/initializers/new_framework_defaults_7_0.rb
+++ b/config/initializers/new_framework_defaults_7_0.rb
@@ -87,7 +87,7 @@ Rails.application.config.action_controller.wrap_parameters_by_default = true
 #
 # See https://guides.rubyonrails.org/configuring.html#config-active-support-use-rfc4122-namespaced-uuids for
 # more information.
-# Rails.application.config.active_support.use_rfc4122_namespaced_uuids = true
+Rails.application.config.active_support.use_rfc4122_namespaced_uuids = true
 
 # Change the default headers to disable browsers' flawed legacy XSS protection.
 # Rails.application.config.action_dispatch.default_headers = {


### PR DESCRIPTION
This setting is being changed to default in Rails v7.
Generated namespaced UUIDs follow the RFC 4122 standard for namespace IDs provided as a String to Digest::UUID.uuid_v3 or Digest::UUID.uuid_v5 method calls.

In Ranguba, we don't use it so there is no effect.

ref: https://guides.rubyonrails.org/v7.0.0/configuring.html#config-active-support-use-rfc4122-namespaced-uuids