### PR TITLE
config action dispatch: disable browsers' flawed legacy XSS protection.

### DIFF
--- a/config/initializers/new_framework_defaults_7_0.rb
+++ b/config/initializers/new_framework_defaults_7_0.rb
@@ -90,14 +90,14 @@ Rails.application.config.action_controller.wrap_parameters_by_default = true
 Rails.application.config.active_support.use_rfc4122_namespaced_uuids = true
 
 # Change the default headers to disable browsers' flawed legacy XSS protection.
-# Rails.application.config.action_dispatch.default_headers = {
-#   "X-Frame-Options" => "SAMEORIGIN",
-#   "X-XSS-Protection" => "0",
-#   "X-Content-Type-Options" => "nosniff",
-#   "X-Download-Options" => "noopen",
-#   "X-Permitted-Cross-Domain-Policies" => "none",
-#   "Referrer-Policy" => "strict-origin-when-cross-origin"
-# }
+Rails.application.config.action_dispatch.default_headers = {
+  "X-Frame-Options" => "SAMEORIGIN",
+  "X-XSS-Protection" => "0",
+  "X-Content-Type-Options" => "nosniff",
+  "X-Download-Options" => "noopen",
+  "X-Permitted-Cross-Domain-Policies" => "none",
+  "Referrer-Policy" => "strict-origin-when-cross-origin"
+}
 
 
 # ** Please read carefully, this must be configured in config/application.rb **


### PR DESCRIPTION
GitHub: ref GH-7

`X-XSS-Protection` setting is no longer needed in modern browsers. Even if we set it, modern browswers don't use it because they has already removed XSS Auditor. And also we had better use Content Security Policy insteaf.

ref: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-XSS-Protection
ref: https://github.com/rails/rails/pull/41769
ref: https://guides.rubyonrails.org/v7.0.0/configuring.html#config-action-dispatch-default-headers