### PR TITLE
config action dispatch: migrate cookie serializer from `:marshal` to `:json`

### DIFF
--- a/config/initializers/cookies_serializer.rb
+++ b/config/initializers/cookies_serializer.rb
@@ -1,5 +1,0 @@
-# Be sure to restart your server when you modify this file.
-
-# Specify a serializer for the signed and encrypted cookie jars.
-# Valid options are :json, :marshal, and :hybrid.
-Rails.application.config.action_dispatch.cookies_serializer = :json

--- a/config/initializers/new_framework_defaults_7_0.rb
+++ b/config/initializers/new_framework_defaults_7_0.rb
@@ -115,7 +115,7 @@ Rails.application.config.action_dispatch.default_headers = {
 # If you're upgrading and haven't set `cookies_serializer` previously, your cookie serializer
 # is `:marshal`. The default for new apps is `:json`.
 #
-# Rails.application.config.action_dispatch.cookies_serializer = :json
+Rails.application.config.action_dispatch.cookies_serializer = :json
 #
 #
 # To migrate an existing application to the `:json` serializer, use the `:hybrid` option.


### PR DESCRIPTION
GitHub: ref GH-7

In Rails v7, this setting defaults to `:json`.

Using `:marshal` as the default value was for backward compatibility with Rails v4.0.
We no longer need this default because we have been using the JSON format by overwriting it in `config/initializers/cookies_serializer.rb`.

In Ranguba, this change has no effect since we don't use cookies.

ref: https://github.com/rails/rails/pull/42538
ref: https://guides.rubyonrails.org/configuring.html#config-action-dispatch-cookies-serializer