### PR TITLE
config action_dispatch: return value of `ActionDispatch::Request#content_type` without modification

### DIFF
--- a/config/initializers/new_framework_defaults_7_0.rb
+++ b/config/initializers/new_framework_defaults_7_0.rb
@@ -137,7 +137,7 @@ Rails.application.config.action_dispatch.cookies_serializer = :json
 # See https://guides.rubyonrails.org/action_controller_overview.html#cookies for more information.
 
 # Change the return value of `ActionDispatch::Request#content_type` to the Content-Type header without modification.
-# Rails.application.config.action_dispatch.return_only_request_media_type_on_content_type = false
+Rails.application.config.action_dispatch.return_only_request_media_type_on_content_type = false
 
 # Added: We dont' use Active Storage in Ranguba. So we don't need it.
 # Active Storage `has_many_attached` relationships will default to replacing the current collection instead of appending to it.


### PR DESCRIPTION
GitHub: ref GH-7

In Rails v7, this setting is default.

Like the following example, `ActionDispatch::Request#content_type` will return the `Content-Type` without modification.
If we want to use only previous `content_type`, we can use `ActionDispatch::Request#media-type`.

Before:

```ruby
request = ActionDispatch::Request.new("CONTENT_TYPE" => "text/csv; header=present; charset=utf-16", "REQUEST_METHOD" => "GET")
request.content_type #=> "text/csv"
```

After:

```ruby
request = ActionDispatch::Request.new("Content-Type" => "text/csv; header=present; charset=utf-16", "REQUEST_METHOD" => "GET")
request.content_type #=> "text/csv; header=present; charset=utf-16"
request.media_type   #=> "text/csv"
```

In Ranguba, there is no effect.

ref: https://developer.mozilla.org/ja/docs/Web/HTTP/Headers/Content-Type
ref: https://github.com/rails/rails/commit/840551307139324300b943901d84cbacba11862d
ref: https://guides.rubyonrails.org/v7.0.0/configuring.html#config-action-dispatch-return-only-request-media-type-on-content-type