### PR TITLE
config active support: disable the deprecated #to_s override

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -36,5 +36,10 @@ module Ranguba
     #
     # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
+
+    # TODO: After upgrading load_defaults to v7.0, we will remove this line because of the default value.
+    # Disables the deprecated #to_s override in some Ruby core classes
+    # See https://guides.rubyonrails.org/configuring.html#config-active-support-disable-to-s-conversion for more information.
+    config.active_support.disable_to_s_conversion = true
   end
 end

--- a/config/initializers/new_framework_defaults_7_0.rb
+++ b/config/initializers/new_framework_defaults_7_0.rb
@@ -144,8 +144,3 @@ Rails.application.config.action_dispatch.return_only_request_media_type_on_conte
 # Thus, to support submitting an empty collection, the `file_field` helper will render an hidden field `include_hidden` by default when `multiple_file_field_include_hidden` is set to `true`.
 # See https://guides.rubyonrails.org/configuring.html#config-active-storage-multiple-file-field-include-hidden for more information.
 # Rails.application.config.active_storage.multiple_file_field_include_hidden = true
-
-# ** Please read carefully, this must be configured in config/application.rb (NOT this file) **
-# Disables the deprecated #to_s override in some Ruby core classes
-# See https://guides.rubyonrails.org/configuring.html#config-active-support-disable-to-s-conversion for more information.
-# config.active_support.disable_to_s_conversion = true


### PR DESCRIPTION
GitHub: ref GH-7

In Rails v7, this setting is default.

Disables the override of the #to_s methods in some Ruby core classes.
This config is for applications that want to take advantage early of a Ruby 3.1 optimization.
- ref: https://github.com/rails/rails/pull/43772

In Ranguba, there is no effect because we don't use the overridden method's function like passing `format` to `to_s`.

ref: https://guides.rubyonrails.org/v7.0.2/configuring.html#config-active-support-disable-to-s-conversion