### PR TITLE
asset: use `url` insteaf of `asset-url`

### DIFF
--- a/app/assets/stylesheets/search.scss
+++ b/app/assets/stylesheets/search.scss
@@ -84,15 +84,15 @@
 }
 
 .topic_path_item_type_label {
-  background-image: asset-url("keys/type-small.png");
+  background-image: url("keys/type-small.png");
 }
 
 .topic_path_item_category_label {
-  background-image: asset-url("keys/category-small.png");
+  background-image: url("keys/category-small.png");
 }
 
 .topic_path_item_query_label {
-  background-image: asset-url("keys/query-small.png");
+  background-image: url("keys/query-small.png");
 }
 
 /* search results */
@@ -178,11 +178,11 @@ li.search_result_drilldown_category_entry {
 }
 
 li.search_result_drilldown_type_entry {
-  background-image: asset-url("keys/type-small.png");
+  background-image: url("keys/type-small.png");
 }
 
 li.search_result_drilldown_category_entry {
-  background-image: asset-url("keys/category-small.png");
+  background-image: url("keys/category-small.png");
 }
 
 /* pagination */


### PR DESCRIPTION
GitHub: ref GH-35

We will remove Sass because `node-sass` which is dependency has already been deprecated.

`asset-url` is provided by `sass-processor` which depends on `sass` gem.
We will use `url` that we can use in CSS instead.

ref: https://github.com/rails/sprockets/blob/5b040f3bec503ded8a98c0c911c7a77dd1f5bf1b/lib/sprockets/sass_processor.rb#L157-L159