### PR TITLE
asset: migrate stylesheets from Sass to CSS

### DIFF
--- a/app/assets/stylesheets/search.css
+++ b/app/assets/stylesheets/search.css
@@ -1,6 +1,7 @@
-// Place all the styles related to the posts controller here.
-// They will automatically be included in application.css.
-// You can use Sass (SCSS) here: http://sass-lang.com/
+/*
+ * Place all the styles related to the posts controller here.
+ * They will automatically be included in application.css.
+ */
 
 /* layout */
 .content {


### PR DESCRIPTION
GitHub: ref GH-35

This pull request migrates the stylesheets from Sass (SCSS) to plain CSS.
The primary reason for this migration is that `node-sass`, a dependency for Sass, has been deprecated.
By transitioning to CSS, we simplify our dependencies and avoid using deprecated tools.

## Changes
- Renamed search.scss to search.css.
- Updated comments format from Sass to CSS style.

## Migration steps

- [x] Change the file extension <- This PR is here.
- [ ] Remove sass-rails