### PR TITLE
Remove sass rails

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 gem "rails", "~> 7.0.0"
 # Use Puma as the app server
 gem "puma", "~> 5.0"
-# Use SCSS for stylesheets
+# Transpile app-like JavaScript. Read more: https://github.com/rails/webpacker
 gem "webpacker", "~> 5.0"
 # Turbolinks makes navigating your web application faster. Read more: https://github.com/turbolinks/turbolinks
 # gem "turbolinks", "~> 5"

--- a/Gemfile
+++ b/Gemfile
@@ -8,8 +8,6 @@ gem "rails", "~> 7.0.0"
 # Use Puma as the app server
 gem "puma", "~> 5.0"
 # Use SCSS for stylesheets
-gem "sass-rails", ">= 6"
-# Transpile app-like JavaScript. Read more: https://github.com/rails/webpacker
 gem "webpacker", "~> 5.0"
 # Turbolinks makes navigating your web application faster. Read more: https://github.com/turbolinks/turbolinks
 # gem "turbolinks", "~> 5"


### PR DESCRIPTION
GitHub: fix GH-35

This PR removed `sass-rails` gem which we don't use because we use pure CSS instead of Sass.
ref: https://github.com/rails/sass-rails