### PR TITLE
Add importmap-rails

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -68,6 +68,8 @@ else
   gem "groonga-client-model"
 end
 
+gem "importmap-rails", "~> 2.0"
+
 gem "kaminari-core"
 gem "kaminari-actionview"
 


### PR DESCRIPTION
GitHub: GH-39

We add Importmap using `importmap-rails` gem which is the default in Rails.
- https://github.com/rails/importmap-rails

Modern Web browswers also support `<script type="importmap">`.
- https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script/type/importmap#browser_compatibility

## What we will do

- [x] Add importmap-rails <- This PR is here.
- [ ] Set up and configure Importmap.
- [ ] Remove the Webpacker dependency.
