### PR TITLE
gem: upgrade Web Console

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,7 +26,7 @@ end
 
 group :development do
   # Access an interactive console on exception pages or by calling "console" anywhere in the code.
-  gem "web-console", ">= 4.1.0"
+  gem "web-console"
   # Display performance information such as SQL time and flame graphs for each request in your browser.
   # Can be configured to work on production as well see: https://github.com/MiniProfiler/rack-mini-profiler/blob/master/README.md
   gem "rack-mini-profiler", "~> 2.0"


### PR DESCRIPTION
GitHub: ref GH-34

Since the Rails repository does not lock the version of Web Console, we will follow the same approach and update to the latest version.

- https://github.com/rails/web-console/blob/main/CHANGELOG.markdown#421
- https://github.com/rails/rails/blob/main/railties/lib/rails/generators/rails/app/templates/Gemfile.tt#L58