### PR TITLE
gem: upgrade Capybara

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,7 +36,7 @@ end
 
 group :test do
   # Adds support for Capybara system testing and selenium driver
-  gem "capybara", ">= 3.26"
+  gem "capybara"
   gem "selenium-webdriver"
   # Easy installation and use of web drivers to run system tests with browsers
   gem "webdrivers"


### PR DESCRIPTION
GitHub: ref https://github.com/ranguba/ranguba/issues/34

This PR upgrade Capybara to the latest version.
Since the Rails repository does not lock the version of Capybara,
we will follow the same approach.

ref: https://github.com/teamcapybara/capybara/blob/master/History.md
ref: https://github.com/rails/rails/blob/7-1-stable/railties/lib/rails/generators/rails/app/templates/Gemfile.tt#L62