### PR TITLE
Drop support for Ruby 2.7

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,6 @@ jobs:
       fail-fast: false
       matrix:
         ruby-version:
-          - "2.7"
           - "3.0"
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
GitHub: fix GH-47

Because Ruby version 2.7 is EOL.
- ref: https://www.ruby-lang.org/en/downloads/branches/