### PR TITLE
ci test: support for the latest Rubies' versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,7 @@ jobs:
       matrix:
         ruby-version:
           - "3.0"
+          - "3.1"
     steps:
       - uses: actions/checkout@v4
       - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,8 @@ jobs:
         ruby-version:
           - "3.0"
           - "3.1"
+          - "3.2"
+          - "3.3"
     steps:
       - uses: actions/checkout@v4
       - uses: actions/checkout@v4


### PR DESCRIPTION
GitHub: fix GH-49

This commit updates the CI workflow to support for the latest Rubies' versions. Keeping up with the latest Ruby ensures compatibility with Ranguba.