### PR TITLE
gem: drop `webdriver` gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,8 +38,6 @@ group :test do
   # Adds support for Capybara system testing and selenium driver
   gem "capybara"
   gem "selenium-webdriver"
-  # Easy installation and use of web drivers to run system tests with browsers
-  gem "webdrivers"
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem


### PR DESCRIPTION
Because `selenium-webdriver` can manage Selenium instead of `webdriver` gem now. And `webdriver` gem recommends us not to use this gem over Selenium (4.11+).

ref: https://github.com/titusfortner/webdrivers?tab=readme-ov-file#update-future-of-this-project
ref: https://github.com/rails/rails/pull/48977