### PR TITLE
gem puma: upgrade Puma

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 # Bundle edge Rails instead: gem "rails", github: "rails/rails", branch: "main"
 gem "rails", "~> 7.0.0"
 # Use Puma as the app server
-gem "puma", "~> 5.0"
+gem "puma"
 # Turbolinks makes navigating your web application faster. Read more: https://github.com/turbolinks/turbolinks
 # gem "turbolinks", "~> 5"
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder


### PR DESCRIPTION
Since the Rails repository does not lock the version of Puma, we will follow the same approach and update to the latest version.

ref: https://github.com/puma/puma/releases
ref: https://github.com/rails/rails/blob/main/railties/lib/rails/generators/app_base.rb#L292