### PR TITLE
config application: remove autoload paths from $LOAD_PATH

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -34,6 +34,11 @@ module Ranguba
     # Common ones are `templates`, `generators`, or `middleware`, for example.
     config.autoload_lib(ignore: %w(assets tasks))
 
+    # Zeitwerk uses absolute file names internally, and your application should
+    # not issue require calls for autoloadable files, so those directories are
+    # actually not needed in $LOAD_PATH anymore.
+    config.add_autoload_paths_to_load_path = false
+
     # Configuration for the application, engines, and railties goes here.
     #
     # These settings can be overridden in specific environments using the files

--- a/config/initializers/new_framework_defaults_7_1.rb
+++ b/config/initializers/new_framework_defaults_7_1.rb
@@ -10,16 +10,6 @@
 # https://guides.rubyonrails.org/upgrading_ruby_on_rails.html
 
 ###
-# No longer add autoloaded paths into `$LOAD_PATH`. This means that you won't be able
-# to manually require files that are managed by the autoloader, which you shouldn't do anyway.
-#
-# This will reduce the size of the load path, making `require` faster if you don't use bootsnap, or reduce the size
-# of the bootsnap cache if you use it.
-#
-# To set this configuration, add the following line to `config/application.rb` (NOT this file):
-#   config.add_autoload_paths_to_load_path = false
-
-###
 # Remove the default X-Download-Options headers since it is used only by Internet Explorer.
 # If you need to support Internet Explorer, add back `"X-Download-Options" => "noopen"`.
 #++


### PR DESCRIPTION
GitHub: ref GH-34

In Rails v7.1, this setting is default.
ref: https://guides.rubyonrails.org/v7.1/configuring.html#config-add-autoload-paths-to-load-path

Zeitwerk uses absolute paths internally, and applications running in `:zeitwerk` mode do not need require_dependency, so models, controllers, jobs, etc. do not need to be in `$LOAD_PATH`.
That's why we don't have to add autoload paths to `$LOAD_PATH` anymore using Zeitwerk.

Note: The `lib` directory is not affected by this flag, it is added to `$LOAD_PATH` always.