### PR TITLE
config action_dispatch: update default headers to remove `X-Download-Options`

### DIFF
--- a/config/initializers/new_framework_defaults_7_1.rb
+++ b/config/initializers/new_framework_defaults_7_1.rb
@@ -13,13 +13,13 @@
 # Remove the default X-Download-Options headers since it is used only by Internet Explorer.
 # If you need to support Internet Explorer, add back `"X-Download-Options" => "noopen"`.
 #++
-# Rails.application.config.action_dispatch.default_headers = {
-#   "X-Frame-Options" => "SAMEORIGIN",
-#   "X-XSS-Protection" => "0",
-#   "X-Content-Type-Options" => "nosniff",
-#   "X-Permitted-Cross-Domain-Policies" => "none",
-#   "Referrer-Policy" => "strict-origin-when-cross-origin"
-# }
+Rails.application.config.action_dispatch.default_headers = {
+  "X-Frame-Options" => "SAMEORIGIN",
+  "X-XSS-Protection" => "0",
+  "X-Content-Type-Options" => "nosniff",
+  "X-Permitted-Cross-Domain-Policies" => "none",
+  "Referrer-Policy" => "strict-origin-when-cross-origin"
+}
 
 ###
 # Do not treat an `ActionController::Parameters` instance


### PR DESCRIPTION
GitHub: ref GH-34

In Rails v7.1, this setting is default.
ref: https://guides.rubyonrails.org/v7.1/configuring.html#config-action-dispatch-default-headers

`X-Download-Options` is used only by Internet Explorer. It will be deprecated soon.
ref: https://github.com/rails/rails/issues/43948