### PR TITLE
config action_controller: configure deprecation warnings for comparing Parameters and Hash

### DIFF
--- a/config/initializers/new_framework_defaults_7_1.rb
+++ b/config/initializers/new_framework_defaults_7_1.rb
@@ -25,7 +25,7 @@ Rails.application.config.action_dispatch.default_headers = {
 # Do not treat an `ActionController::Parameters` instance
 # as equal to an equivalent `Hash` by default.
 #++
-# Rails.application.config.action_controller.allow_deprecated_parameters_hash_equality = false
+Rails.application.config.action_controller.allow_deprecated_parameters_hash_equality = false
 
 ###
 # Active Record Encryption now uses SHA-256 as its hash digest algorithm.


### PR DESCRIPTION
GitHub: ref GH-34

This setting is default in Rails v7.1.

When comparing `ActionController::Parameters` and `Hash`, the system now emits a configurable deprecation message.
This behavior is controlled by this setting. Now the default setting is false. So it suppress these deprecations.