### PR TITLE
config active_record: disable support for encryption using SHA-1

### DIFF
--- a/config/initializers/new_framework_defaults_7_1.rb
+++ b/config/initializers/new_framework_defaults_7_1.rb
@@ -46,7 +46,7 @@ Rails.application.config.action_controller.allow_deprecated_parameters_hash_equa
 # 3. If you don't currently have data encrypted with Active Record encryption, you can disable this setting to
 # configure the default behavior starting 7.1+:
 #++
-# Rails.application.config.active_record.encryption.support_sha1_for_non_deterministic_encryption = false
+Rails.application.config.active_record.encryption.support_sha1_for_non_deterministic_encryption = false
 
 ###
 # No longer run after_commit callbacks on the first of multiple Active Record


### PR DESCRIPTION
GitHub: ref GH-34

This setting is default in Rails v7.1.
ref: https://guides.rubyonrails.org/v7.1/configuring.html#config-active-record-encryption-support-sha1-for-non-deterministic-encryption

This change disables support for decrypting data that was encrypted using a SHA-1 digest class.

In Ranguba, we do not utilize this encryption feature, so this change will not impact us.