### PR TITLE
config active job: enable the Active Job `BigDecimal` argument serializer

### DIFF
--- a/config/initializers/new_framework_defaults_7_1.rb
+++ b/config/initializers/new_framework_defaults_7_1.rb
@@ -83,7 +83,7 @@ Rails.application.config.action_controller.allow_deprecated_parameters_hash_equa
 # serializer. Therefore, this setting should only be enabled after all replicas
 # have been successfully upgraded to Rails 7.1.
 #++
-# Rails.application.config.active_job.use_big_decimal_serializer = true
+Rails.application.config.active_job.use_big_decimal_serializer = true
 
 ###
 # Specify if an `ArgumentError` should be raised if `Rails.cache` `fetch` or


### PR DESCRIPTION
GitHub: ref GH-34

As of Rails v7.1, this setting is default
- https://guides.rubyonrails.org/v7.1/configuring.html#config-active-job-use-big-decimal-serializer

It enables the new BigDecimal argument serializer for arguments of jobs. In Ranguba, we don't use Active Job's feature in this moment so there is no impacts to us.