### PR TITLE
config active support: enable raising ArgumentError in `Rails.cache`.

### DIFF
--- a/config/initializers/new_framework_defaults_7_1.rb
+++ b/config/initializers/new_framework_defaults_7_1.rb
@@ -91,7 +91,7 @@ Rails.application.config.action_controller.allow_deprecated_parameters_hash_equa
 # Options are `true`, and `false`. If `false`, the exception will be reported
 # as `handled` and logged instead.
 #++
-# Rails.application.config.active_support.raise_on_invalid_cache_expiration_time = true
+Rails.application.config.active_support.raise_on_invalid_cache_expiration_time = true
 
 ###
 # Specify whether Query Logs will format tags using the SQLCommenter format


### PR DESCRIPTION
GitHub: ref GH-34

As of Rails v7.1, this setting is default.

- https://guides.rubyonrails.org/v7.1/configuring.html#config-active-support-raise-on-invalid-cache-expiration-time

It will raise an ArgumentError if `Rails.cache` fetch or write are given an invalid `expires_at` or `expires_in` time.

In Ranguba, we don't use it so there is no impact on us.