### PR TITLE
config active support: migrate message serializer to `ActiveSupport::JSON`

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -46,5 +46,10 @@ module Ranguba
     #
     # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
+
+    # TODO: Remove this configuration at Rails 7.2 because it will be default.
+    #       Use `ActiveSupport::JSON` as the default serializer for `MessageEncryptor`
+    #       and `MessageVerifier` instances.
+    config.active_support.message_serializer = :json
   end
 end

--- a/config/initializers/new_framework_defaults_7_1.rb
+++ b/config/initializers/new_framework_defaults_7_1.rb
@@ -75,7 +75,7 @@ Rails.application.config.active_support.raise_on_invalid_cache_expiration_time =
 # servers, first deploy without changing the serializer, then set the serializer
 # in a subsequent deploy.
 #++
-# Rails.application.config.active_support.message_serializer = :json_allow_marshal
+Rails.application.config.active_support.message_serializer = :json_allow_marshal
 
 ###
 # Enable a performance optimization that serializes message data and metadata

--- a/config/initializers/new_framework_defaults_7_1.rb
+++ b/config/initializers/new_framework_defaults_7_1.rb
@@ -48,36 +48,6 @@ Rails.application.config.active_job.use_big_decimal_serializer = true
 Rails.application.config.active_support.raise_on_invalid_cache_expiration_time = true
 
 ###
-# Specify the default serializer used by `MessageEncryptor` and `MessageVerifier`
-# instances.
-#
-# The legacy default is `:marshal`, which is a potential vector for
-# deserialization attacks in cases where a message signing secret has been
-# leaked.
-#
-# In Rails 7.1, the new default is `:json_allow_marshal` which serializes and
-# deserializes with `ActiveSupport::JSON`, but can fall back to deserializing
-# with `Marshal` so that legacy messages can still be read.
-#
-# In Rails 7.2, the default will become `:json` which serializes and
-# deserializes with `ActiveSupport::JSON` only.
-#
-# Alternatively, you can choose `:message_pack` or `:message_pack_allow_marshal`,
-# which serialize with `ActiveSupport::MessagePack`. `ActiveSupport::MessagePack`
-# can roundtrip some Ruby types that are not supported by JSON, and may provide
-# improved performance, but it requires the `msgpack` gem.
-#
-# For more information, see
-# https://guides.rubyonrails.org/v7.1/configuring.html#config-active-support-message-serializer
-#
-# If you are performing a rolling deploy of a Rails 7.1 upgrade, wherein servers
-# that have not yet been upgraded must be able to read messages from upgraded
-# servers, first deploy without changing the serializer, then set the serializer
-# in a subsequent deploy.
-#++
-Rails.application.config.active_support.message_serializer = :json_allow_marshal
-
-###
 # Enable a performance optimization that serializes message data and metadata
 # together. This changes the message format, so messages serialized this way
 # cannot be read by older versions of Rails. However, messages that use the old


### PR DESCRIPTION
GitHub: GH-34

As of Rails v7.1, this setting is default.
- ref: https://guides.rubyonrails.org/v7.1/configuring.html#config-active-support-message-serializer

We migrated it to `ActiveSupport::JSON`.
Because `Marshal` is a potential vector for deserialization attacks in cases where a message signing secret has been leaked.

In Ranguba, we don't explicitly use it, so there is no impact on us.