### PR TITLE
config active_support: enables a performance optimization that serializes message data and metadata

### DIFF
--- a/config/initializers/new_framework_defaults_7_1.rb
+++ b/config/initializers/new_framework_defaults_7_1.rb
@@ -58,7 +58,7 @@ Rails.application.config.active_support.raise_on_invalid_cache_expiration_time =
 # leave this optimization off on the first deploy, then enable it on a
 # subsequent deploy.
 #++
-# Rails.application.config.active_support.use_message_serializer_for_metadata = true
+Rails.application.config.active_support.use_message_serializer_for_metadata = true
 
 ###
 # Set the maximum size for Rails log files.


### PR DESCRIPTION
GitHub: GH-34

As of Rails v7.1, this setting is default.

ref: https://guides.rubyonrails.org/v7.1/configuring.html#config-active-support-use-message-serializer-for-metadata

Enabling this prevents reading messages from previous Rails (<7.1) versions,
but since Ranguba doesn't use this feature, it has no impact on us.