### PR TITLE
config: set the maximum size for Rails log files

### DIFF
--- a/config/initializers/new_framework_defaults_7_1.rb
+++ b/config/initializers/new_framework_defaults_7_1.rb
@@ -66,9 +66,9 @@ Rails.application.config.active_support.raise_on_invalid_cache_expiration_time =
 # `config.load_defaults 7.1` does not set this value for environments other than
 # development and test.
 #++
-# if Rails.env.local?
-#   Rails.application.config.log_file_size = 100 * 1024 * 1024
-# end
+if Rails.env.local?
+  Rails.application.config.log_file_size = 100 * 1024 * 1024
+end
 
 ###
 # Enable precompilation of `config.filter_parameters`. Precompilation can


### PR DESCRIPTION
GitHub: GH-34

As of Rails v7.1, this setting is default.
- https://guides.rubyonrails.org/v7.1/configuring.html#config-log-file-size

On local, this setting set the maximum size for Rails logs. This change won't has impact on us because it's for only local.