### PR TITLE
config: use `ActiveSupport::ParameterFilter.precompile_filters` for parameters

### DIFF
--- a/config/initializers/new_framework_defaults_7_1.rb
+++ b/config/initializers/new_framework_defaults_7_1.rb
@@ -74,7 +74,7 @@ end
 # Enable precompilation of `config.filter_parameters`. Precompilation can
 # improve filtering performance, depending on the quantity and types of filters.
 #++
-# Rails.application.config.precompile_filter_parameters = true
+Rails.application.config.precompile_filter_parameters = true
 
 ###
 # ** Please read carefully, this must be configured in config/application.rb **


### PR DESCRIPTION
GitHub: GH-34

As of Rails v7.1, this setting is default.
- https://guides.rubyonrails.org/v7.1/configuring.html#config-precompile-filter-parameters

This change can improve filtering performance such as with per-request instances in `ActionDispatch::Http::FilterParameters`.
- https://github.com/rails/rails/pull/46452