### PR TITLE
config action_view: use HTML5-compliant sanitizers

### DIFF
--- a/config/initializers/new_framework_defaults_7_1.rb
+++ b/config/initializers/new_framework_defaults_7_1.rb
@@ -100,7 +100,7 @@ end
 #
 # In previous versions of Rails, Action View always used `Rails::HTML4::Sanitizer` as its vendor.
 #++
-# Rails.application.config.action_view.sanitizer_vendor = Rails::HTML::Sanitizer.best_supported_vendor
+Rails.application.config.action_view.sanitizer_vendor = Rails::HTML::Sanitizer.best_supported_vendor
 
 ###
 # Configure the log level used by the DebugExceptions middleware when logging


### PR DESCRIPTION
GitHub: ref GH-34

As of Rails v7.1, this setting is default.
- https://guides.rubyonrails.org/v7.1/configuring.html#config-action-view-sanitizer-vendor

Due to its dependency on libxml2's HTML4 parser, `Rails::HTML4::Sanitizer` is increasingly inadequate for modern web applications. As this parser has not been updated to fully support HTML5, using `Rails::HTML4::Sanitizer` exposes applications to potential security vulnerabilities and compatibility issues with contemporary web standards.
- https://github.com/rails/rails/pull/48293