### PR TITLE
config action dispatch: configure the log level of DebugExceptions to error

### DIFF
--- a/config/initializers/new_framework_defaults_7_1.rb
+++ b/config/initializers/new_framework_defaults_7_1.rb
@@ -106,7 +106,7 @@ Rails.application.config.action_view.sanitizer_vendor = Rails::HTML::Sanitizer.b
 # Configure the log level used by the DebugExceptions middleware when logging
 # uncaught exceptions during requests.
 #++
-# Rails.application.config.action_dispatch.debug_exception_log_level = :error
+Rails.application.config.action_dispatch.debug_exception_log_level = :error
 
 ###
 # Configure the test helpers in Action View, Action Dispatch, and rails-dom-testing to use HTML5


### PR DESCRIPTION
GitHub: ref GH-34

As of Rails v7.1, this setting is default.

- https://guides.rubyonrails.org/v7.1/configuring.html#config-action-dispatch-debug-exception-log-level

This change configures the log level used by the [ActionDispatch::DebugExceptions](https://api.rubyonrails.org/v7.1.4/classes/ActionDispatch/DebugExceptions.html) middleware from `fatal` to `error` when logging uncaught exceptions during requests.
Because `ActionDispatch::DebugExceptions` won't deal with unhandleable errors like fatal error but handleable errors.

- https://github.com/rails/rails/pull/48575