### PR TITLE
config: migrate dom_testing_default_html_version from `:html4` to `:html5`

### DIFF
--- a/config/initializers/new_framework_defaults_7_1.rb
+++ b/config/initializers/new_framework_defaults_7_1.rb
@@ -116,4 +116,4 @@ Rails.application.config.action_view.sanitizer_vendor = Rails::HTML::Sanitizer.b
 #
 # In previous versions of Rails, these test helpers always used an HTML4 parser.
 #++
-# Rails.application.config.dom_testing_default_html_version = :html5
+Rails.application.config.dom_testing_default_html_version = :html5


### PR DESCRIPTION
GitHub: ref GH-34

As of Rails v7.1, this setting is default.

- https://guides.rubyonrails.org/v7.1/configuring.html#config-dom-testing-default-html-version

Since end users use HTML5, it is important to update the HTML parsers used in test helpers to reflect real-world usage.

- https://github.com/rails/rails/pull/48682